### PR TITLE
Expose full TranscriptionResult

### DIFF
--- a/SherpaONNXUnity/Assets/Demo/Collection/OfflineSpeechRecognition/Scripts/OfflineSpeechRecognitionExample.cs
+++ b/SherpaONNXUnity/Assets/Demo/Collection/OfflineSpeechRecognition/Scripts/OfflineSpeechRecognitionExample.cs
@@ -6,6 +6,7 @@ namespace Eitan.SherpaONNXUnity.Samples
     using Eitan.Sherpa.Onnx.Unity.Mono.Components;
     using Eitan.Sherpa.Onnx.Unity.Mono.Inputs;
     using Eitan.SherpaONNXUnity.Runtime;
+    using Eitan.SherpaONNXUnity.Runtime.Modules;
     using UnityEngine;
     using UnityEngine.UI;
     using UnityEngine.Events;
@@ -359,15 +360,15 @@ namespace Eitan.SherpaONNXUnity.Samples
 
             try
             {
-                var transcript = await offlineRecognizer.TranscribeClipAsync(clip, operationCts?.Token ?? CancellationToken.None).ConfigureAwait(true);
-                if (string.IsNullOrWhiteSpace(transcript))
+                var result = await offlineRecognizer.TranscribeClipAsync(clip, operationCts?.Token ?? CancellationToken.None).ConfigureAwait(true);
+                if (result.Status != SpeechRecognition.TranscriptionStatus.Success || string.IsNullOrWhiteSpace(result.Text))
                 {
                     statusText.text = "No transcript returned.";
                     return;
                 }
 
                 statusText.text = "Transcription complete.";
-                HandleTranscriptReady(transcript);
+                HandleTranscriptReady(result);
             }
             catch (System.Exception ex)
             {
@@ -375,8 +376,9 @@ namespace Eitan.SherpaONNXUnity.Samples
             }
         }
 
-        private void HandleTranscriptReady(string text)
+        private void HandleTranscriptReady(SpeechRecognition.TranscriptionResult result)
         {
+            var text = result.Text;
             if (string.IsNullOrWhiteSpace(text))
             {
                 return;

--- a/SherpaONNXUnity/Assets/Demo/Collection/RealtimeSpeechRecognition/Scripts/RealtimeSpeechRecognitionExample.cs
+++ b/SherpaONNXUnity/Assets/Demo/Collection/RealtimeSpeechRecognition/Scripts/RealtimeSpeechRecognitionExample.cs
@@ -10,6 +10,7 @@ namespace Eitan.SherpaONNXUnity.Samples
     using Eitan.Sherpa.Onnx.Unity.Mono.Components;
     using Eitan.Sherpa.Onnx.Unity.Mono.Inputs;
     using Eitan.SherpaONNXUnity.Runtime;
+    using Eitan.SherpaONNXUnity.Runtime.Modules;
     using UnityEngine;
     using UnityEngine.UI;
     using Stage = Eitan.SherpaONNXUnity.Samples.ModelLoadProgressTracker.Stage;
@@ -276,8 +277,9 @@ namespace Eitan.SherpaONNXUnity.Samples
             UpdateButtonVisuals();
         }
 
-        private void HandleTranscriptReady(string transcript)
+        private void HandleTranscriptReady(SpeechRecognition.TranscriptionResult result)
         {
+            var transcript = result.Text;
             if (string.IsNullOrWhiteSpace(transcript))
             {
                 return;

--- a/SherpaONNXUnity/Packages/com.eitan.sherpa-onnx-unity/Runtime/Modules/SpeechRecognition.cs
+++ b/SherpaONNXUnity/Packages/com.eitan.sherpa-onnx-unity/Runtime/Modules/SpeechRecognition.cs
@@ -63,18 +63,31 @@ namespace Eitan.SherpaONNXUnity.Runtime.Modules
 
         public readonly struct TranscriptionResult
         {
-            public TranscriptionResult(TranscriptionStatus status, string text = "", bool isFinal = false, Exception error = null)
+            public TranscriptionResult(
+                TranscriptionStatus status,
+                string text = "",
+                bool isFinal = false,
+                Exception error = null,
+                string[] tokens = null,
+                float[] timestamps = null,
+                float[] durations = null)
             {
                 Status = status;
                 Text = text ?? string.Empty;
                 IsFinal = isFinal;
                 Error = error;
+                Tokens = tokens ?? Array.Empty<string>();
+                Timestamps = timestamps ?? Array.Empty<float>();
+                Durations = durations ?? Array.Empty<float>();
             }
 
             public TranscriptionStatus Status { get; }
             public string Text { get; }
             public bool IsFinal { get; }
             public Exception Error { get; }
+            public string[] Tokens { get; }
+            public float[] Timestamps { get; }
+            public float[] Durations { get; }
         }
 
         protected override SherpaONNXModuleType ModuleType => SherpaONNXModuleType.SpeechRecognition;
@@ -681,8 +694,10 @@ namespace Eitan.SherpaONNXUnity.Runtime.Modules
                     }
 
                     var text = result?.Text ?? string.Empty;
+                    var tokens = result?.Tokens ?? Array.Empty<string>();
+                    var timestamps = result?.Timestamps ?? Array.Empty<float>();
                     var cased = PostProcessCasing(text);
-                    return Task.FromResult(new TranscriptionResult(TranscriptionStatus.Success, cased, isFinal));
+                    return Task.FromResult(new TranscriptionResult(TranscriptionStatus.Success, cased, isFinal, tokens: tokens, timestamps: timestamps));
                 }
             });
         }
@@ -723,16 +738,24 @@ namespace Eitan.SherpaONNXUnity.Runtime.Modules
                 }
 
                 // Create new offline stream for each transcription
-                string result = string.Empty;
+                string text;
+                string[] tokens;
+                float[] timestamps;
+                float[] durations;
                 using (var offlineStream = _offlineRecognizer.CreateStream())
                 {
                     offlineStream.AcceptWaveform(sampleRate, audioSamplesFrame);
                     combinedCt.ThrowIfCancellationRequested();
                     _offlineRecognizer.Decode(offlineStream);
-                    result = offlineStream.Result.Text;
-                    result = PostProcessCasing(result);
+                    var nativeResult = offlineStream.Result;
+                    text = nativeResult.Text;
+                    tokens = nativeResult.Tokens;
+                    timestamps = nativeResult.Timestamps;
+                    durations = nativeResult.Durations;
+
+                    text = PostProcessCasing(text);
                 }
-                return Task.FromResult(new TranscriptionResult(TranscriptionStatus.Success, result, isFinal: true));
+                return Task.FromResult(new TranscriptionResult(TranscriptionStatus.Success, text, isFinal: true, tokens: tokens, timestamps: timestamps, durations: durations));
             });
         }
 

--- a/SherpaONNXUnity/Packages/com.eitan.sherpa-onnx-unity/Runtime/Mono/Components/OfflineSpeechRecognizerComponent.cs
+++ b/SherpaONNXUnity/Packages/com.eitan.sherpa-onnx-unity/Runtime/Mono/Components/OfflineSpeechRecognizerComponent.cs
@@ -40,7 +40,7 @@ namespace Eitan.Sherpa.Onnx.Unity.Mono.Components
 
         [Header("Events")]
         [SerializeField]
-        private UnityEvent<string> onTranscriptReady = new UnityEvent<string>();
+        private UnityEvent<SpeechRecognition.TranscriptionResult> onTranscriptReady = new UnityEvent<SpeechRecognition.TranscriptionResult>();
 
         [SerializeField]
         private UnityEvent<string> onTranscriptionFailed = new UnityEvent<string>();
@@ -48,7 +48,7 @@ namespace Eitan.Sherpa.Onnx.Unity.Mono.Components
         /// <summary>
         /// Public hook for scripts that want to display offline transcripts without using the inspector.
         /// </summary>
-        public UnityEvent<string> TranscriptReadyEvent => onTranscriptReady;
+        public UnityEvent<SpeechRecognition.TranscriptionResult> TranscriptReadyEvent => onTranscriptReady;
 
         /// <summary>
         /// Public hook for scripts to surface error messages.
@@ -139,7 +139,7 @@ namespace Eitan.Sherpa.Onnx.Unity.Mono.Components
             return Module?.StartInitialization(cancellationToken) ?? Task.CompletedTask;
         }
 
-        public async Task<string> TranscribeClipAsync(AudioClip clip, CancellationToken cancellationToken = default)
+        public async Task<SpeechRecognition.TranscriptionResult> TranscribeClipAsync(AudioClip clip, CancellationToken cancellationToken = default)
         {
             if (clip == null)
             {
@@ -148,14 +148,13 @@ namespace Eitan.Sherpa.Onnx.Unity.Mono.Components
 
             if (!EnsureModuleReady(out var module))
             {
-                return string.Empty;
+                return new SpeechRecognition.TranscriptionResult(SpeechRecognition.TranscriptionStatus.NotReady);
             }
 
             var data = new float[clip.samples * clip.channels];
             clip.GetData(data, 0);
             var mono = DownmixToMono(data, clip.channels);
-            var result = await module.TranscribeAsync(mono, clip.frequency, cancellationToken).ConfigureAwait(false);
-            return result.Status == SpeechRecognition.TranscriptionStatus.Success ? result.Text ?? string.Empty : string.Empty;
+            return await module.TranscribeAsync(mono, clip.frequency, cancellationToken).ConfigureAwait(false);
         }
 
         private void HandleSpeechSegment(float[] samples, int sampleRate)
@@ -224,8 +223,7 @@ namespace Eitan.Sherpa.Onnx.Unity.Mono.Components
                 var result = await module.TranscribeAsync(chunk.Samples, chunk.SampleRate, token).ConfigureAwait(false);
                 if (result.Status == SpeechRecognition.TranscriptionStatus.Success && !string.IsNullOrWhiteSpace(result.Text))
                 {
-                    var text = result.Text.Trim();
-                    DispatchToUnity(() => onTranscriptReady?.Invoke(text));
+                    DispatchToUnity(() => onTranscriptReady?.Invoke(result));
                 }
                 else if (result.Status == SpeechRecognition.TranscriptionStatus.Error && result.Error != null)
                 {

--- a/SherpaONNXUnity/Packages/com.eitan.sherpa-onnx-unity/Runtime/Mono/Components/SpeechRecognizerComponent.cs
+++ b/SherpaONNXUnity/Packages/com.eitan.sherpa-onnx-unity/Runtime/Mono/Components/SpeechRecognizerComponent.cs
@@ -261,7 +261,6 @@ namespace Eitan.Sherpa.Onnx.Unity.Mono.Components
 
                     if (result.Status == SpeechRecognition.TranscriptionStatus.Success && !string.IsNullOrWhiteSpace(result.Text))
                     {
-                        var text = result.Text.Trim();
                         DispatchToUnity(() => PublishTranscript(result));
                     }
                     else if (result.Status == SpeechRecognition.TranscriptionStatus.Error && result.Error != null)

--- a/SherpaONNXUnity/Packages/com.eitan.sherpa-onnx-unity/Runtime/Mono/Components/SpeechRecognizerComponent.cs
+++ b/SherpaONNXUnity/Packages/com.eitan.sherpa-onnx-unity/Runtime/Mono/Components/SpeechRecognizerComponent.cs
@@ -33,7 +33,7 @@ namespace Eitan.Sherpa.Onnx.Unity.Mono.Components
 
         [Header("Transcription Events")]
         [SerializeField]
-        private UnityEvent<string> onTranscriptionReady = new UnityEvent<string>();
+        private UnityEvent<SpeechRecognition.TranscriptionResult> onTranscriptionReady = new UnityEvent<SpeechRecognition.TranscriptionResult>();
 
         [Header("Streaming")]
         [SerializeField]
@@ -68,7 +68,7 @@ namespace Eitan.Sherpa.Onnx.Unity.Mono.Components
         /// <summary>
         /// Allows scripts to subscribe to transcription updates without relying on the inspector.
         /// </summary>
-        public UnityEvent<string> TranscriptionReadyEvent => onTranscriptionReady;
+        public UnityEvent<SpeechRecognition.TranscriptionResult> TranscriptionReadyEvent => onTranscriptionReady;
 
         private readonly Queue<AudioChunk> pendingChunks = new Queue<AudioChunk>();
         private readonly object queueLock = new object();
@@ -262,7 +262,7 @@ namespace Eitan.Sherpa.Onnx.Unity.Mono.Components
                     if (result.Status == SpeechRecognition.TranscriptionStatus.Success && !string.IsNullOrWhiteSpace(result.Text))
                     {
                         var text = result.Text.Trim();
-                        DispatchToUnity(() => PublishTranscript(text));
+                        DispatchToUnity(() => PublishTranscript(result));
                     }
                     else if (result.Status == SpeechRecognition.TranscriptionStatus.Error && result.Error != null)
                     {
@@ -286,15 +286,15 @@ namespace Eitan.Sherpa.Onnx.Unity.Mono.Components
             }
         }
 
-        private void PublishTranscript(string text)
+        private void PublishTranscript(SpeechRecognition.TranscriptionResult result)
         {
-            if (deduplicateStreamingResults && string.Equals(text, lastTranscript, StringComparison.Ordinal))
+            if (deduplicateStreamingResults && string.Equals(result.Text, lastTranscript, StringComparison.Ordinal))
             {
                 return;
             }
 
-            lastTranscript = text;
-            onTranscriptionReady?.Invoke(text);
+            lastTranscript = result.Text;
+            onTranscriptionReady?.Invoke(result);
         }
 
         protected override void OnAudioChunkReceived(float[] samples, int sampleRate)

--- a/SherpaONNXUnity/Packages/com.eitan.sherpa-onnx-unity/Runtime/Utilities/Pinyin/PinyinUtil.cs
+++ b/SherpaONNXUnity/Packages/com.eitan.sherpa-onnx-unity/Runtime/Utilities/Pinyin/PinyinUtil.cs
@@ -273,7 +273,7 @@ namespace Eitan.SherpaONNXUnity.Runtime.Utilities.Pinyin
 
             if (format.Contains(CAPITALIZE_FIRST_LETTER))
             {
-                return CapitalizeFirstLetter(pinyin); ;
+                return CapitalizeFirstLetter(pinyin);
             }
             if (format.Contains(LOWERCASE))
             {


### PR DESCRIPTION
Expose the full TranscriptionResult (text, tokens, timestamps, durations), instead of only the text.

close #14

### Remarks
- I tested this with a breakpoint in OfflineSpeechRecognition example. Is this sufficient?
  - Might make sense to have basic automated unit tests in the future (maybe in a separate ticket)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transcription results now include token, timestamp, and duration data alongside recognized text.

* **Style**
  * Minor code cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->